### PR TITLE
Update AtlasLoot_MythicWotLK.lua

### DIFF
--- a/src/AtlasLoot_Mythic/AtlasLoot_MythicWotLK.lua
+++ b/src/AtlasLoot_Mythic/AtlasLoot_MythicWotLK.lua
@@ -1481,3 +1481,19 @@ AtlasLoot_Data["MythicHallsOfReflectionTheLichKing"] = {
 		instance = "MythicFHHallsOfReflection",
 	};
 }
+
+-------------
+--- Misc. ---
+-------------
+
+AtlasLoot_Data["MythicRaidsPlaceholderWotLK"] = {
+	["Normal"] = {
+		{
+			{ 1, 0, "achievement_character_human_male", "=q6=Come back later, kid.", "=ds=There's no loot here yet."},
+		}
+	},
+	info = {
+		name = "Meh's Bodyguard",
+		module = moduleName,
+	},
+};


### PR DESCRIPTION
added placeholder for mythic raids to avoid confusion of empty loot table.