### PR TITLE
Update AtlasLoot_MythicBC.lua

### DIFF
--- a/src/AtlasLoot_Mythic/AtlasLoot_MythicBC.lua
+++ b/src/AtlasLoot_Mythic/AtlasLoot_MythicBC.lua
@@ -1397,3 +1397,19 @@ AtlasLoot_Data["MythicMagistersTerraceKaelthasSunstrider"] = {
 		instance = "MythicMagistersTerrace",
 	},
 };
+
+-------------
+--- Misc. ---
+-------------
+
+AtlasLoot_Data["MythicRaidsPlaceholderTBC"] = {
+	["Normal"] = {
+		{
+			{ 1, 0, "achievement_character_human_male", "=q6=Come back later, kid.", "=ds=There's no loot here yet."},
+		}
+	},
+	info = {
+		name = "Meh's Bodyguard",
+		module = moduleName,
+	},
+};


### PR DESCRIPTION
added placeholder for mythic raids to avoid confusion of empty loot table.