### PR TITLE
Feature: Alt Click > Loot DB Search, Moved Attune preview to Tooltip

### DIFF
--- a/src/AtlasLoot/Core/AtlasLoot.lua
+++ b/src/AtlasLoot/Core/AtlasLoot.lua
@@ -1008,41 +1008,25 @@ function AtlasLoot:ShowLootPage(dataID, pFrame)
 	self.ItemFrame.dataID = saveDataID
 	self.ItemFrame.lootTableType = lootTableType
 
-	-- boss name include attune status
-	local bossName = self:GetTableInfo(saveDataID, false, true, true, attunable, attuned, attunableOverall, attunedOverall, forgeable, forged, forgeableOverall, forgedOverall)
+	-- ʕ •ᴥ•ʔ✿ Clean boss name without attune info ✿ʕ •ᴥ•ʔ
+	local bossName = self:GetTableInfo(saveDataID, false, true, true)
 	self.ItemFrame.BossName:SetText(bossName)
 
-  local attuneText = ""
- 	if attunable ~= nil and attuned ~= nil then
- 		attuneText = attuned .. "/" .. attunable
- 	end
+	-- ʕ •ᴥ•ʔ✿ Attune display removed - info only in tooltip ✿ʕ •ᴥ•ʔ
 
-  local titanForgeText = "N/A"
-  if titanForged ~= nil then
- 		titanForgeText = titanForged
- 	end
+	-- ʕ •ᴥ•ʔ✿ Store attune info for tooltip ✿ʕ •ᴥ•ʔ
+	self.ItemFrame.BossName.attuneInfo = {
+		attunable = attunable,
+		attuned = attuned,
+		titanForged = titanForged,
+		warForged = warForged,
+		lightForged = lightForged
+	}
 
-  local warForgeText = "N/A"
-  if warForged ~= nil then
- 		warForgeText = warForged
- 	end
-
-  local lightForgeText = "N/A"
-  if lightForged ~= nil then
- 		lightForgeText = lightForged
- 	end
-
-	self.ItemFrame.AttuneFrame:SetText(attuneText)
-	self.ItemFrame.AttuneFrame:SetVertexColor(0.65, 1, 0.5)
-
-	self.ItemFrame.TitanForgedFrame:SetText(titanForgeText)
-	self.ItemFrame.TitanForgedFrame:SetVertexColor(0.5, 0.5, 1)
-
-	self.ItemFrame.WarForgedFrame:SetText(warForgeText)
-	self.ItemFrame.WarForgedFrame:SetVertexColor(1, 0.65, 0.5)
-
-	self.ItemFrame.LightForgedFrame:SetText(lightForgeText)
-	self.ItemFrame.LightForgedFrame:SetVertexColor(1, 1, 0.65)
+	-- ʕ •ᴥ•ʔ✿ Hide individual forge frames (moved to compact display) ✿ʕ •ᴥ•ʔ
+	self.ItemFrame.TitanForgedFrame:SetText("")
+	self.ItemFrame.WarForgedFrame:SetText("")
+	self.ItemFrame.LightForgedFrame:SetText("")
 
   AtlasLoot:DefaultFrame_SetAttuneInfo(attunableOverall, attunedOverall, titanForgeableOverall, titanForgedOverall, warForgeableOverall, warForgedOverall, lightForgeableOverall, lightForgedOverall)
 
@@ -1135,6 +1119,56 @@ function AtlasLoot:ShowLootPage(dataID, pFrame)
 		self:SetEnableQuickLook(self:GetEnableQuickLook())
 	end
 	-- AtlasLoot:QueryLootPage()
+end
+
+-- ʕ •ᴥ•ʔ✿ Tooltip functions for boss name ✿ʕ •ᴥ•ʔ
+function AtlasLoot:BossName_OnEnter(button)
+	if not self.ItemFrame or not self.ItemFrame.BossName or not self.ItemFrame.BossName.attuneInfo then
+		return
+	end
+	
+	local attuneInfo = self.ItemFrame.BossName.attuneInfo
+	local hasInfo = false
+	
+	-- Check if there's any attune information to display
+	if (attuneInfo.attunable and attuneInfo.attunable > 0) or 
+	   (attuneInfo.titanForged and attuneInfo.titanForged > 0) or 
+	   (attuneInfo.warForged and attuneInfo.warForged > 0) or 
+	   (attuneInfo.lightForged and attuneInfo.lightForged > 0) then
+		
+		GameTooltip:SetOwner(button, "ANCHOR_BOTTOM")
+		GameTooltip:SetText(self.ItemFrame.BossName:GetText(), 1, 1, 1)
+		
+		if attuneInfo.attunable and attuneInfo.attunable > 0 then
+			GameTooltip:AddLine("Attuned: " .. (attuneInfo.attuned or 0) .. "/" .. attuneInfo.attunable, 0.65, 1, 0.5)
+			hasInfo = true
+		end
+		
+		if attuneInfo.titanForged and attuneInfo.titanForged > 0 then
+			GameTooltip:AddLine("Titanforged: " .. attuneInfo.titanForged, 0.5, 0.5, 1)
+			hasInfo = true
+		end
+		
+		if attuneInfo.warForged and attuneInfo.warForged > 0 then
+			GameTooltip:AddLine("Warforged: " .. attuneInfo.warForged, 1, 0.65, 0.5)
+			hasInfo = true
+		end
+		
+		if attuneInfo.lightForged and attuneInfo.lightForged > 0 then
+			GameTooltip:AddLine("Lightforged: " .. attuneInfo.lightForged, 1, 1, 0.65)
+			hasInfo = true
+		end
+		
+		if hasInfo then
+			GameTooltip:Show()
+		else
+			GameTooltip:Hide()
+		end
+	end
+end
+
+function AtlasLoot:BossName_OnLeave(button)
+	GameTooltip:Hide()
 end
 
 -- Table format (wishlist, filter, ...)

--- a/src/AtlasLoot/Core/ItemFrame_GUI.lua
+++ b/src/AtlasLoot/Core/ItemFrame_GUI.lua
@@ -52,34 +52,52 @@ function AtlasLoot:CreateItemFrame()
 	Frame.BossName:SetText("")
 	Frame.BossName:SetWidth(512)
 	Frame.BossName:SetHeight(30)
+	
+	-- ʕ •ᴥ•ʔ✿ Make boss name interactive for tooltip ✿ʕ •ᴥ•ʔ
+	Frame.BossNameButton = CreateFrame("Button", "AtlasLoot_BossNameButton", Frame)
+	Frame.BossNameButton:SetPoint("TOP", Frame, "TOP", -25, 0)
+	Frame.BossNameButton:SetWidth(512)
+	Frame.BossNameButton:SetHeight(30)
+	Frame.BossNameButton:SetScript("OnEnter", function(self)
+		AtlasLoot:BossName_OnEnter(self)
+	end)
+	Frame.BossNameButton:SetScript("OnLeave", function(self)
+		AtlasLoot:BossName_OnLeave(self)
+	end)
 
-	Frame.AttuneFrame = Frame:CreateFontString("AtlasLoot_BossName","OVERLAY","GameFontHighlightLarge")
-	Frame.AttuneFrame:SetPoint("TOP", Frame, "TOP", -25 - 90, 0)
-	Frame.AttuneFrame:SetJustifyH("RIGHT")
+	-- ʕ •ᴥ•ʔ✿ Hidden attune frame - info moved to tooltip only ✿ʕ •ᴥ•ʔ
+	Frame.AttuneFrame = Frame:CreateFontString("AtlasLoot_AttuneFrame","OVERLAY","GameFontNormalSmall")
+	Frame.AttuneFrame:SetPoint("TOP", Frame, "TOP", -1000, 0) -- Move offscreen
+	Frame.AttuneFrame:SetJustifyH("CENTER")
 	Frame.AttuneFrame:SetText("")
-	Frame.AttuneFrame:SetWidth(512)
-	Frame.AttuneFrame:SetHeight(30)
+	Frame.AttuneFrame:SetWidth(1)
+	Frame.AttuneFrame:SetHeight(1)
+	Frame.AttuneFrame:Hide()
 
-	Frame.TitanForgedFrame = Frame:CreateFontString("AtlasLoot_BossName","OVERLAY","GameFontHighlightLarge")
-	Frame.TitanForgedFrame:SetPoint("TOP", Frame, "TOP", -25 - 60, 0)
-	Frame.TitanForgedFrame:SetJustifyH("RIGHT")
+	-- ʕ •ᴥ•ʔ✿ Hide individual forge frames - info moved to tooltip ✿ʕ •ᴥ•ʔ
+	Frame.TitanForgedFrame = Frame:CreateFontString("AtlasLoot_TitanForgedFrame","OVERLAY","GameFontNormalSmall")
+	Frame.TitanForgedFrame:SetPoint("TOP", Frame, "TOP", -1000, 0) -- Move offscreen
+	Frame.TitanForgedFrame:SetJustifyH("CENTER")
 	Frame.TitanForgedFrame:SetText("")
-	Frame.TitanForgedFrame:SetWidth(512)
-	Frame.TitanForgedFrame:SetHeight(30)
+	Frame.TitanForgedFrame:SetWidth(1)
+	Frame.TitanForgedFrame:SetHeight(1)
+	Frame.TitanForgedFrame:Hide()
 
-	Frame.WarForgedFrame = Frame:CreateFontString("AtlasLoot_BossName","OVERLAY","GameFontHighlightLarge")
-	Frame.WarForgedFrame:SetPoint("TOP", Frame, "TOP", -25 - 30, 0)
-	Frame.WarForgedFrame:SetJustifyH("RIGHT")
+	Frame.WarForgedFrame = Frame:CreateFontString("AtlasLoot_WarForgedFrame","OVERLAY","GameFontNormalSmall")
+	Frame.WarForgedFrame:SetPoint("TOP", Frame, "TOP", -1000, 0) -- Move offscreen
+	Frame.WarForgedFrame:SetJustifyH("CENTER")
 	Frame.WarForgedFrame:SetText("")
-	Frame.WarForgedFrame:SetWidth(512)
-	Frame.WarForgedFrame:SetHeight(30)
+	Frame.WarForgedFrame:SetWidth(1)
+	Frame.WarForgedFrame:SetHeight(1)
+	Frame.WarForgedFrame:Hide()
 
-	Frame.LightForgedFrame = Frame:CreateFontString("AtlasLoot_BossName","OVERLAY","GameFontHighlightLarge")
-	Frame.LightForgedFrame:SetPoint("TOP", Frame, "TOP", -25 - 0, 0)
-	Frame.LightForgedFrame:SetJustifyH("RIGHT")
+	Frame.LightForgedFrame = Frame:CreateFontString("AtlasLoot_LightForgedFrame","OVERLAY","GameFontNormalSmall")
+	Frame.LightForgedFrame:SetPoint("TOP", Frame, "TOP", -1000, 0) -- Move offscreen
+	Frame.LightForgedFrame:SetJustifyH("CENTER")
 	Frame.LightForgedFrame:SetText("")
-	Frame.LightForgedFrame:SetWidth(512)
-	Frame.LightForgedFrame:SetHeight(30)
+	Frame.LightForgedFrame:SetWidth(1)
+	Frame.LightForgedFrame:SetHeight(1)
+	Frame.LightForgedFrame:Hide()
 
 	Frame.ItemButtons = {}
 	for i=1,30 do

--- a/src/AtlasLoot/Core/LootButtons.lua
+++ b/src/AtlasLoot/Core/LootButtons.lua
@@ -1541,8 +1541,17 @@ function AtlasLoot:ItemOnClick(arg1)
 		elseif arg1 == "RightButton" and itemRarity and itemRarity == 7 and self.par.info then
 			AtlasLoot:ShowHeriloomConfigWindow(self.par.info)
 		end
+	elseif IsControlKeyDown() and IsAltKeyDown() then
+		-- ʕ •ᴥ•ʔ✿ Ctrl+Alt+Click reserved for wishlist (handled by WishList module) ✿ʕ •ᴥ•ʔ
+		-- This condition prevents conflict with individual key handlers
 	elseif IsControlKeyDown() then
 		self.par:DressUp()
+	elseif IsAltKeyDown() and self.par.info and self.par.info[2] then
+		-- ʕ •ᴥ•ʔ✿ Alt+Click to open item in LootDb ✿ʕ •ᴥ•ʔ
+		local itemID = self.par.info[2]
+		if itemID and type(itemID) == "number" then
+			OpenLootDb(itemID)
+		end
 	end
 end
 

--- a/src/AtlasLoot/Modules/DefaultFrame.lua
+++ b/src/AtlasLoot/Modules/DefaultFrame.lua
@@ -292,35 +292,35 @@ do
 		Frame.VersionNumber:SetText(ATLASLOOT_VERSION_NUM.." ( FrameStyle by Atlas )")
 
 		Frame.InstanceName = Frame:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
-		Frame.InstanceName:SetPoint("TOPLEFT", Frame, "TOPLEFT", 546, -97)
+		Frame.InstanceName:SetPoint("TOPLEFT", Frame, "TOPLEFT", 544, -91) -- ʕ •ᴥ•ʔ✿ Adjusted 2px left, 6px up ✿ʕ •ᴥ•ʔ
 		Frame.InstanceName:SetJustifyH("LEFT")
 		Frame.InstanceName:SetWidth(351)
 		Frame.InstanceName:SetHeight(30)
 		Frame.InstanceName:SetText("")
 
 		Frame.OverallAttuneFrame = Frame:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
-		Frame.OverallAttuneFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 546, -97  - 15 * 1)
+		Frame.OverallAttuneFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 544, -91 - 15 * 1) -- ʕ •ᴥ•ʔ✿ Adjusted 2px left, 6px up ✿ʕ •ᴥ•ʔ
 		Frame.OverallAttuneFrame:SetJustifyH("LEFT")
 		Frame.OverallAttuneFrame:SetWidth(351)
     Frame.OverallAttuneFrame:SetHeight(30)
 		Frame.OverallAttuneFrame:SetText("")
 
 		Frame.OverallTitanForgedFrame = Frame:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
-		Frame.OverallTitanForgedFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 546, -97 - 15 * 2)
+		Frame.OverallTitanForgedFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 544, -91 - 15 * 2) -- ʕ •ᴥ•ʔ✿ Adjusted 2px left, 6px up ✿ʕ •ᴥ•ʔ
 		Frame.OverallTitanForgedFrame:SetJustifyH("LEFT")
 		Frame.OverallTitanForgedFrame:SetWidth(351)
     Frame.OverallTitanForgedFrame:SetHeight(30)
 		Frame.OverallTitanForgedFrame:SetText("")
 
 		Frame.OverallWarForgedFrame = Frame:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
-		Frame.OverallWarForgedFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 546, -97 - 15 * 3)
+		Frame.OverallWarForgedFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 544, -91 - 15 * 3) -- ʕ •ᴥ•ʔ✿ Adjusted 2px left, 6px up ✿ʕ •ᴥ•ʔ
 		Frame.OverallWarForgedFrame:SetJustifyH("LEFT")
 		Frame.OverallWarForgedFrame:SetWidth(351)
     Frame.OverallWarForgedFrame:SetHeight(30)
 		Frame.OverallWarForgedFrame:SetText("")
 
 		Frame.OverallLightForgedFrame = Frame:CreateFontString(nil, "ARTWORK", "GameFontHighlightLarge")
-		Frame.OverallLightForgedFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 546, -97 - 15 * 4)
+		Frame.OverallLightForgedFrame:SetPoint("TOPLEFT", Frame, "TOPLEFT", 544, -91 - 15 * 4) -- ʕ •ᴥ•ʔ✿ Adjusted 2px left, 6px up ✿ʕ •ᴥ•ʔ
 		Frame.OverallLightForgedFrame:SetJustifyH("LEFT")
 		Frame.OverallLightForgedFrame:SetWidth(351)
     Frame.OverallLightForgedFrame:SetHeight(30)
@@ -544,6 +544,13 @@ function DefaultFrame:SetInstanceTable()
 				DefaultFrame.Frame.ScrollFrame.Buttons[buttonNum].Loot:Show()
 				DefaultFrame.Frame.ScrollFrame.Buttons[buttonNum].Selected:Hide()
 				DefaultFrame.Frame.ScrollFrame.Buttons[buttonNum].boss = v[1]
+				-- ʕ •ᴥ•ʔ✿ Add tooltip functionality for attune info ✿ʕ •ᴥ•ʔ
+				DefaultFrame.Frame.ScrollFrame.Buttons[buttonNum]:SetScript("OnEnter", function(self)
+					DefaultFrame:BossButton_OnEnter(self)
+				end)
+				DefaultFrame.Frame.ScrollFrame.Buttons[buttonNum]:SetScript("OnLeave", function(self)
+					DefaultFrame:BossButton_OnLeave(self)
+				end)
 				if not curBoss then
 					DefaultFrame.Frame.ScrollFrame.Buttons[buttonNum]:Click()
 				end
@@ -578,6 +585,81 @@ function DefaultFrame:SetBoss(boss)
 			return
 		end
 	end
+end
+
+-- ʕ •ᴥ•ʔ✿ Calculate attune info for tooltip without changing display ✿ʕ •ᴥ•ʔ
+function DefaultFrame:CalculateBossAttuneInfo(dataID)
+	local lootTable = AtlasLoot:GetLootPageFromDataID(dataID)
+	if not lootTable then return 0, 0, 0, 0, 0, 0, 0, 0 end
+	
+	local attunable, attuned, titanForgeable, titanForged, warForgeable, warForged, lightForgeable, lightForged = 0, 0, 0, 0, 0, 0, 0, 0
+	
+	-- Calculate attune info for this boss's items without affecting display
+	for k,v in ipairs(lootTable) do
+		if v and type(v) == "table" then
+			local itemId = v[2]
+			if itemId ~= nil and itemId ~= 0 and type(itemId) == 'number' then
+				if CanAttuneItemHelper and CanAttuneItemHelper(itemId) > 0 then
+					attunable = attunable + 1
+					titanForgeable = titanForgeable + 1
+					warForgeable = warForgeable + 1
+					lightForgeable = lightForgeable + 1
+					if GetItemAttuneProgress and GetItemAttuneProgress(itemId, nil, nil) >= 100 then
+						attuned = attuned + 1
+						if GetItemAttuneForge then
+							local forgeLevel = GetItemAttuneForge(itemId)
+							if forgeLevel == 1 then
+								titanForged = titanForged + 1
+							elseif forgeLevel == 2 then
+								warForged = warForged + 1
+							elseif forgeLevel == 3 then
+								lightForged = lightForged + 1
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+	
+	return attunable, attuned, titanForgeable, titanForged, warForgeable, warForged, lightForgeable, lightForged
+end
+
+-- ʕ •ᴥ•ʔ✿ Tooltip functions for boss buttons ✿ʕ •ᴥ•ʔ
+function DefaultFrame:BossButton_OnEnter(button)
+	if not button or not button.boss then return end
+	
+	local dataID = button.boss
+	-- ʕ •ᴥ•ʔ✿ Get boss-specific attune info WITHOUT changing display ✿ʕ •ᴥ•ʔ
+	local attunable, attuned, titanForgeable, titanForged, warForgeable, warForged, lightForgeable, lightForged = self:CalculateBossAttuneInfo(dataID)
+	
+	-- Only show tooltip if there's attune information
+	if (attunable and attunable > 0) or (titanForged and titanForged > 0) or (warForged and warForged > 0) or (lightForged and lightForged > 0) then
+		GameTooltip:SetOwner(button, "ANCHOR_RIGHT")
+		GameTooltip:SetText(button.Text:GetText(), 1, 1, 1)
+		
+		if attunable and attunable > 0 then
+			GameTooltip:AddLine("Attuned: " .. (attuned or 0) .. "/" .. attunable, 0.65, 1, 0.5)
+		end
+		
+		if titanForged and titanForged > 0 then
+			GameTooltip:AddLine("Titanforged: " .. titanForged, 0.5, 0.5, 1)
+		end
+		
+		if warForged and warForged > 0 then
+			GameTooltip:AddLine("Warforged: " .. warForged, 1, 0.65, 0.5)
+		end
+		
+		if lightForged and lightForged > 0 then
+			GameTooltip:AddLine("Lightforged: " .. lightForged, 1, 1, 0.65)
+		end
+		
+		GameTooltip:Show()
+	end
+end
+
+function DefaultFrame:BossButton_OnLeave(button)
+	GameTooltip:Hide()
 end
 
 -- instance table creator

--- a/src/AtlasLoot/Modules/WishList.lua
+++ b/src/AtlasLoot/Modules/WishList.lua
@@ -480,7 +480,8 @@ end
 
 -- onClick of a itemButton
 function WishList:ButtonOnClick(arg1)
-	if not self.par.tableLink and IsAltKeyDown() then
+	if not self.par.tableLink and IsAltKeyDown() and IsControlKeyDown() then
+		-- ʕ •ᴥ•ʔ✿ Ctrl+Alt+Click to add item to wishlist ✿ʕ •ᴥ•ʔ
 		self.par:AddItemToWishList()
 	end
 end

--- a/src/AtlasLoot_Loader/Info.lua
+++ b/src/AtlasLoot_Loader/Info.lua
@@ -55,11 +55,15 @@ AtlasLoot.AddonInfo = {
 		},
 		{
 			AL["How to add an item to the wishlist:"],
-			AL["Alt+Left Click any item to add it to the wishlist."],
+			AL["Ctrl+Alt+Left Click any item to add it to the wishlist."],
 		},
 		{
 			AL["How to delete an item from the wishlist:"],
-			AL["While on the wishlist screen, just Alt+Left Click on an item to delete it."],
+			AL["While on the wishlist screen, just Ctrl+Alt+Left Click on an item to delete it."],
+		},
+		{
+			AL["How to open an item in LootDb:"],
+			AL["Alt+Left Click any item to open it in LootDb."],
 		},
 		{
 			AL["What else does the wishlist do?"],


### PR DESCRIPTION
Alt Click -> OpenLootDB
Ctrl + Alt -> Previous Alt Click > Wishlist

Changed previous attune display to a tooltip, caused issue with long boss overlapping Added tooltip to boss hover to quickly view attunes in each boss